### PR TITLE
Fix plugin load order

### DIFF
--- a/nvim/lua/gmm/init.lua
+++ b/nvim/lua/gmm/init.lua
@@ -1,3 +1,4 @@
-require("gmm.remap")
+-- load the plugin manager before any mappings that depend on plugins
 require("gmm.lazy")
+require("gmm.remap")
 


### PR DESCRIPTION
## Summary
- ensure the plugin manager loads before key mappings that rely on plugins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68823d5949a083329418592bea98f7f7