### PR TITLE
Fix missing setup_handlers

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -1,11 +1,21 @@
 local mason_lspconfig = require("mason-lspconfig")
 local lsp = require("gmm.lsp")
 
-mason_lspconfig.setup_handlers({
-    function(server_name)
+-- mason-lspconfig versions prior to v2 do not implement `setup_handlers`.
+-- To remain compatible we fall back to manually setting up installed servers
+-- when the helper is unavailable.
+if mason_lspconfig.setup_handlers then
+    mason_lspconfig.setup_handlers({
+        function(server_name)
+            lsp.setup(server_name)
+        end,
+    })
+else
+    mason_lspconfig.setup()
+    for _, server_name in ipairs(mason_lspconfig.get_installed_servers()) do
         lsp.setup(server_name)
-    end,
-})
+    end
+end
 
 -- start jdtls automatically for Java files
 vim.api.nvim_create_autocmd("FileType", {


### PR DESCRIPTION
## Summary
- fix LSP setup so old versions of mason-lspconfig work

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68824361d5dc8332a1113d6af1d98a62