### PR TITLE
Fix mason setup order

### DIFF
--- a/nvim/after/plugin/lsp.lua
+++ b/nvim/after/plugin/lsp.lua
@@ -1,5 +1,13 @@
+-- Ensure mason is initialized before using mason-lspconfig
+require("mason").setup()
+
 local mason_lspconfig = require("mason-lspconfig")
 local lsp = require("gmm.lsp")
+
+-- Install servers automatically when they're configured via lspconfig
+mason_lspconfig.setup({
+    automatic_installation = true,
+})
 
 -- mason-lspconfig versions prior to v2 do not implement `setup_handlers`.
 -- To remain compatible we fall back to manually setting up installed servers

--- a/nvim/after/plugin/mason.lua
+++ b/nvim/after/plugin/mason.lua
@@ -1,4 +1,0 @@
-require("mason").setup()
-require("mason-lspconfig").setup({
-	automatic_installation = true
-})


### PR DESCRIPTION
## Summary
- ensure `mason.nvim` loads before `mason-lspconfig.nvim`
- remove redundant plugin config

## Testing
- `nvim --headless "+qa"`

------
https://chatgpt.com/codex/tasks/task_e_6882449fd260833296db4f13c9f58925