### PR TITLE
Fix harpoon leader key

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,3 +1,4 @@
+vim.g.mapleader = " "
 require("gmm")
 
 

--- a/nvim/lua/gmm/remap.lua
+++ b/nvim/lua/gmm/remap.lua
@@ -1,6 +1,6 @@
 -- Key mappings for gmm
+
 -- <leader> is space, <leader>pv opens Ex
-vim.g.mapleader = " "
 
 -- use 4 spaces for indentation
 vim.opt.tabstop = 4


### PR DESCRIPTION
## Summary
- set `vim.g.mapleader` early so harpoon mappings use `<leader>`
- remove redundant `mapleader` assignment from `remap.lua`

## Testing
- `nvim --headless +quit`
- `XDG_CONFIG_HOME=$PWD nvim --headless +"lua print(vim.g.mapleader)" +q` *(fails: triggered plugin install)*

------
https://chatgpt.com/codex/tasks/task_e_68825571f3c083328a8ff70659e28eef