### PR TITLE
Remove kitty graphics setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,8 @@ required during startup.
 
 The `alacritty` directory contains `alacritty.toml` with my terminal
 preferences.  It applies the
-[Tokyo Night](https://github.com/folke/tokyonight.nvim) colour scheme, enables
-Kitty's inline image protocol and sets the font size to `16` with ligatures
-enabled.  Copy or symlink the file to
+[Tokyo Night](https://github.com/folke/tokyonight.nvim) colour scheme and sets the
+font size to `16` with ligatures enabled.  Copy or symlink the file to
 `~/.config/alacritty/alacritty.toml` to use it.
 
 ### Keyboard shortcuts

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -45,10 +45,6 @@ index = 17
 color = '#db4b4b'
 
 
-# Enable Kitty graphics protocol for inline images
-[terminal]
-kitty_graphics = true
-
 # Font configuration with ligatures
 [font]
 size = 16.0


### PR DESCRIPTION
## Summary
- remove `kitty_graphics` since Alacritty warns it is unused
- update README to stop mentioning kitty graphics

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68835639c9b08332a0ce8e2da64cd6d7