### PR TITLE
Remove unused features from Alacritty config

### DIFF
--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -45,7 +45,6 @@ index = 17
 color = '#db4b4b'
 
 
-# Font configuration with ligatures
+# Font configuration
 [font]
 size = 16.0
-features = ["liga"]


### PR DESCRIPTION
## Summary
- remove the `features` line from `alacritty.toml` because ligatures are not supported
- tidy up the font configuration comment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688357683e488332aacf3b95f85c7ff9