### PR TITLE
Add Vim-style copy mode to WezTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,27 @@ font size to `16` with ligatures enabled.  Copy or symlink the file to
 | `Ctrl+Shift+W` | Close window |
 | `Ctrl+Shift+Space` | Enter select mode |
 | `F11` | Toggle fullscreen |
+
+## WezTerm config
+
+The `wezterm` directory contains `wezterm.lua` mirroring the Alacritty theme and font size.
+Copy or symlink the file to `~/.config/wezterm/wezterm.lua` to use it.
+It also maps `Ctrl+Shift+Space` to enter a Vim-style copy mode for selecting and yanking from the scrollback.
+
+### Keyboard shortcuts
+
+| Shortcut | Action |
+| -------- | ------ |
+| `Ctrl+Shift+C` | Copy selection |
+| `Ctrl+Shift+V` | Paste clipboard |
+| `Ctrl+Shift+F` | Search scrollback |
+| `Ctrl+Shift+R` | Reload configuration |
+| `Ctrl+Shift++` | Increase font size |
+| `Ctrl+-` | Decrease font size |
+| `Ctrl+0` | Reset font size |
+| `Ctrl+Shift+T` | New tab |
+| `Ctrl+Shift+N` | New window |
+| `Ctrl+Shift+W` | Close tab or window |
+| `Ctrl+Shift+Space` | Enter copy mode |
+| `Alt+Enter` | Toggle fullscreen |
+| `Ctrl+Shift+Left/Right` | Cycle tabs |

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -1,0 +1,40 @@
+local wezterm = require 'wezterm'
+
+return {
+  font_size = 16.0,
+  colors = {
+    foreground = '#c0caf5',
+    background = '#1a1b26',
+    ansi = {
+      '#15161e',
+      '#f7768e',
+      '#9ece6a',
+      '#e0af68',
+      '#7aa2f7',
+      '#bb9af7',
+      '#7dcfff',
+      '#a9b1d6',
+    },
+    brights = {
+      '#414868',
+      '#ff899d',
+      '#9fe044',
+      '#faba4a',
+      '#8db0ff',
+      '#c7a9ff',
+      '#a4daff',
+      '#c0caf5',
+    },
+    indexed = {
+      [16] = '#ff9e64',
+      [17] = '#db4b4b',
+    },
+  },
+  keys = {
+    {
+      key = 'Space',
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.ActivateCopyMode,
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- map `Ctrl+Shift+Space` to activate copy mode in `wezterm.lua`
- document WezTerm's Vim-style copy mode in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68835dac25748332b79e94c86857e1c2