### PR TITLE
Configure Option keys for composing in WezTerm

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -1,6 +1,9 @@
 local wezterm = require 'wezterm'
 
 return {
+  -- let both Option keys produce composed characters like '#'
+  send_composed_key_when_left_alt_is_pressed  = true,
+  send_composed_key_when_right_alt_is_pressed = true,
   font_size = 16.0,
   colors = {
     foreground = '#c0caf5',


### PR DESCRIPTION
## Summary
- allow the left and right Option keys to send composed characters in WezTerm

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837edb3fa083328d0ebb73c036db42