### PR TITLE
Fix: disable netrw panel

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,4 +1,9 @@
 vim.g.mapleader = " "
+
+-- disable netrw to prevent the file panel from opening automatically
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
 require("gmm")
 
 


### PR DESCRIPTION
## Summary
- stop netrw from loading so it can't pop up a file panel

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688381c862688332b018f69ae125fb05