### PR TITLE
Disable neo-tree

### DIFF
--- a/nvim/lua/gmm/lazy.lua
+++ b/nvim/lua/gmm/lazy.lua
@@ -50,6 +50,7 @@ require("lazy").setup({
   {
     "nvim-neo-tree/neo-tree.nvim",
     branch = "v3.x",
+    enabled = false,
     dependencies = {
       "nvim-lua/plenary.nvim",
       "nvim-tree/nvim-web-devicons",


### PR DESCRIPTION
## Summary
- disable `neo-tree` in lazy plugin list to avoid automatic file tree

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688385b4e78c83328be3ffbfc0e988ad