### PR TITLE
Fix Ex command mapping

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,9 +1,4 @@
 vim.g.mapleader = " "
 
--- disable netrw to prevent the file panel from opening automatically
-vim.g.loaded_netrw = 1
-vim.g.loaded_netrwPlugin = 1
-
 require("gmm")
-
 


### PR DESCRIPTION
## Summary
- enable the Ex command in Neovim by removing `loaded_netrw` lines

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883887b01ec8332949ea199ba7fe6a2