### PR TITLE
Add smart-splits and tmux-like wezterm setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,29 @@ It also maps `Ctrl+Shift+Space` to enter a Vim-style copy mode for selecting and
 | `Ctrl+Shift+Space` | Enter copy mode |
 | `Alt+Enter` | Toggle fullscreen |
 | `Ctrl+Shift+Left/Right` | Cycle tabs |
+
+### Pane management cheat sheet
+
+**Neovim (smart-splits.nvim)**
+
+| Shortcut | Action |
+| -------- | ------ |
+| `<C-h>`/`<C-j>`/`<C-k>`/`<C-l>` | Move focus to adjacent split |
+| `<C-S-h>`/`<C-S-j>`/`<C-S-k>`/`<C-S-l>` | Resize current split |
+| `:split` / `:vsplit` | Create horizontal/vertical split |
+
+**WezTerm (tmux style)**
+
+The leader key is `Ctrl+a`.
+
+| Shortcut | Action |
+| -------- | ------ |
+| `Leader + \\` | Split pane horizontally |
+| `Leader + -` | Split pane vertically |
+| `Ctrl+h/j/k/l` | Move between panes |
+| `Ctrl+Shift+h/j/k/l` | Resize active pane |
+| `Leader + m` | Toggle pane zoom |
+| `Leader + c` | New tab |
+| `Leader + p` / `Leader + n` | Previous/next tab |
+| `Leader + [1-9]` | Switch to tab number |
+| `Leader + [` | Enter copy mode |

--- a/nvim/after/plugin/smart-splits.lua
+++ b/nvim/after/plugin/smart-splits.lua
@@ -1,0 +1,15 @@
+local smart_splits = require("smart-splits")
+
+smart_splits.setup({
+  default_amount = 5,
+})
+
+vim.keymap.set("n", "<C-h>", smart_splits.move_cursor_left)
+vim.keymap.set("n", "<C-j>", smart_splits.move_cursor_down)
+vim.keymap.set("n", "<C-k>", smart_splits.move_cursor_up)
+vim.keymap.set("n", "<C-l>", smart_splits.move_cursor_right)
+
+vim.keymap.set("n", "<C-S-h>", smart_splits.resize_left)
+vim.keymap.set("n", "<C-S-j>", smart_splits.resize_down)
+vim.keymap.set("n", "<C-S-k>", smart_splits.resize_up)
+vim.keymap.set("n", "<C-S-l>", smart_splits.resize_right)

--- a/nvim/lua/gmm/lazy.lua
+++ b/nvim/lua/gmm/lazy.lua
@@ -40,6 +40,9 @@ require("lazy").setup({
     dependencies = { "nvim-lua/plenary.nvim" },
   },
 
+  -- Smart splits for better pane navigation
+  { "mrjones2014/smart-splits.nvim", lazy = false },
+
   -- Treesitter
   { "nvim-treesitter/nvim-treesitter", build = ":TSUpdate" },
   { "nvim-treesitter/nvim-treesitter-context" },

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -1,43 +1,143 @@
-local wezterm = require 'wezterm'
+local wezterm = require("wezterm")
+local mux = wezterm.mux
 
-return {
-  -- let both Option keys produce composed characters like '#'
-  send_composed_key_when_left_alt_is_pressed  = true,
-  send_composed_key_when_right_alt_is_pressed = true,
-  font_size = 16.0,
-  colors = {
-    foreground = '#c0caf5',
-    background = '#1a1b26',
-    ansi = {
-      '#15161e',
-      '#f7768e',
-      '#9ece6a',
-      '#e0af68',
-      '#7aa2f7',
-      '#bb9af7',
-      '#7dcfff',
-      '#a9b1d6',
-    },
-    brights = {
-      '#414868',
-      '#ff899d',
-      '#9fe044',
-      '#faba4a',
-      '#8db0ff',
-      '#c7a9ff',
-      '#a4daff',
-      '#c0caf5',
-    },
-    indexed = {
-      [16] = '#ff9e64',
-      [17] = '#db4b4b',
-    },
+wezterm.on("gui-startup", function(cmd)
+  local tab, pane, window = mux.spawn_window(cmd or {})
+  window:gui_window():maximize()
+end)
+
+local config = wezterm.config_builder()
+
+config.term = "xterm-256color"
+config.send_composed_key_when_left_alt_is_pressed = true
+config.send_composed_key_when_right_alt_is_pressed = true
+
+local direction_keys = {
+  h = "Left",
+  j = "Down",
+  k = "Up",
+  l = "Right",
+}
+
+local function split_nav(key)
+  return {
+    key = key,
+    mods = "CTRL",
+    action = wezterm.action_callback(function(win, pane)
+      if pane:get_user_vars().IS_NVIM == "true" then
+        win:perform_action({ SendKey = { key = key, mods = "CTRL" } }, pane)
+      else
+        win:perform_action({ ActivatePaneDirection = direction_keys[key] }, pane)
+      end
+    end),
+  }
+end
+
+config.font_size = 16
+config.colors = {
+  foreground = '#c0caf5',
+  background = '#1a1b26',
+  ansi = {
+    '#15161e',
+    '#f7768e',
+    '#9ece6a',
+    '#e0af68',
+    '#7aa2f7',
+    '#bb9af7',
+    '#7dcfff',
+    '#a9b1d6',
   },
-  keys = {
-    {
-      key = 'Space',
-      mods = 'CTRL|SHIFT',
-      action = wezterm.action.ActivateCopyMode,
-    },
+  brights = {
+    '#414868',
+    '#ff899d',
+    '#9fe044',
+    '#faba4a',
+    '#8db0ff',
+    '#c7a9ff',
+    '#a4daff',
+    '#c0caf5',
+  },
+  indexed = {
+    [16] = '#ff9e64',
+    [17] = '#db4b4b',
   },
 }
+config.window_decorations = "RESIZE"
+config.window_padding = {
+  top = 10,
+  bottom = 10,
+  left = 10,
+  right = 10,
+}
+
+config.leader = { key = "a", mods = "CTRL", timeout_milliseconds = 2000 }
+
+local action = wezterm.action
+
+config.keys = {
+  {
+    key = "\\",
+    mods = "LEADER",
+    action = action.SplitHorizontal({ domain = "CurrentPaneDomain" }),
+  },
+  split_nav("h"),
+  split_nav("j"),
+  split_nav("k"),
+  split_nav("l"),
+  {
+    key = "h",
+    mods = "CTRL|SHIFT",
+    action = action.AdjustPaneSize({ "Left", 5 }),
+  },
+  {
+    key = "l",
+    mods = "CTRL|SHIFT",
+    action = action.AdjustPaneSize({ "Right", 5 }),
+  },
+  {
+    key = "j",
+    mods = "CTRL|SHIFT",
+    action = action.AdjustPaneSize({ "Down", 5 }),
+  },
+  {
+    key = "k",
+    mods = "CTRL|SHIFT",
+    action = action.AdjustPaneSize({ "Up", 5 }),
+  },
+  {
+    key = "-",
+    mods = "LEADER",
+    action = action.SplitVertical({ domain = "CurrentPaneDomain" }),
+  },
+  {
+    key = "m",
+    mods = "LEADER",
+    action = action.TogglePaneZoomState,
+  },
+  { key = "[", mods = "LEADER", action = action.ActivateCopyMode },
+  {
+    key = "c",
+    mods = "LEADER",
+    action = action.SpawnTab("CurrentPaneDomain"),
+  },
+  {
+    key = "p",
+    mods = "LEADER",
+    action = action.ActivateTabRelative(-1),
+  },
+  {
+    key = "n",
+    mods = "LEADER",
+    action = action.ActivateTabRelative(1),
+  },
+}
+
+for i = 1, 9 do
+  table.insert(config.keys, {
+    key = tostring(i),
+    mods = "LEADER",
+    action = action.ActivateTab(i - 1),
+  })
+end
+
+return config


### PR DESCRIPTION
## Summary
- enable smart pane navigation via `smart-splits.nvim`
- configure wezterm to mimic tmux with leader key and pane management
- add pane management cheatsheet to the README

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838a1c37b4833283c3852494559d01