### PR TITLE
Fix wezterm padding on HiDPI displays

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -64,10 +64,10 @@ config.colors = {
 }
 config.window_decorations = "RESIZE"
 config.window_padding = {
-  top = 10,
-  bottom = 10,
-  left = 10,
-  right = 10,
+  top = '2cell',
+  bottom = '2cell',
+  left = '2cell',
+  right = '2cell',
 }
 
 config.leader = { key = "a", mods = "CTRL", timeout_milliseconds = 2000 }


### PR DESCRIPTION
## Summary
- align wezterm padding with terminal cell size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68868b0df1948332a617f4aa585016e5