### PR TITLE
Fix wezterm window buffer_scale note

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ a multiple of the display scale factor. Leaving
 `adjust_window_size_when_changing_font_size` at its default value ensures that
 font size changes keep the window dimensions valid.
 
+If the window still fails to start on a high-DPI monitor (for example at 200%
+scale), make sure you're running a recent WezTerm release (2024 or later) and
+have the config in `~/.config/wezterm/wezterm.lua`. Older versions may ignore
+cell units and produce the buffer_scale error regardless of padding.
+
 ### Keyboard shortcuts
 
 | Shortcut | Action |

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -70,6 +70,9 @@ config.window_padding = {
   right = '2cell',
 }
 
+-- Prevent Wayland buffer scale errors when toggling font size on HiDPI displays
+config.adjust_window_size_when_changing_font_size = true
+
 config.leader = { key = "a", mods = "CTRL", timeout_milliseconds = 2000 }
 
 local action = wezterm.action


### PR DESCRIPTION
## Summary
- note WezTerm must be a recent version for padding to work on Wayland
- explicitly keep `adjust_window_size_when_changing_font_size` enabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68868c94485c83328ac84dca141458f2