### PR TITLE
Disable WezTerm exit confirmation

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -63,6 +63,7 @@ config.colors = {
   },
 }
 config.window_decorations = "RESIZE"
+config.window_close_confirmation = "NeverPrompt"
 config.window_padding = {
   top = '2cell',
   bottom = '2cell',


### PR DESCRIPTION
## Summary
- eliminate exit confirmation by setting `window_close_confirmation = "NeverPrompt"`

## Testing
- `luacheck wezterm/wezterm.lua`


------
https://chatgpt.com/codex/tasks/task_e_688c8d20a6c48332b115e645f623efd9