### PR TITLE
Improve AeroSpace workspace controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ From this repo:
 ./install.sh
 ```
 
-The installer links AeroSpace, Neovim, tmux, and zsh into the expected config
-locations, creates `~/.zshrc.local`, and installs TPM if it is missing. Ghostty
+The installer renders AeroSpace and links Neovim, tmux, and zsh into the expected
+config locations, creates `~/.zshrc.local`, and installs TPM if it is missing. Ghostty
 config is linked only when Ghostty is installed or `DOTFILES_INSTALL_GHOSTTY=1`
 is set. Use `--headless` on servers to skip Ghostty even if it is installed. If
 a real file or directory already exists where a link should go, the script
@@ -22,18 +22,21 @@ the zsh source line unchanged.
 
 ## AeroSpace setup
 
-The AeroSpace config lives at `aerospace/aerospace.toml` and is symlinked to
-`~/.config/aerospace/aerospace.toml`.
+The shared AeroSpace config lives at `aerospace/aerospace.toml`. Machine-specific
+window routes live in `aerospace/hosts/<hostname>.toml`; `install.sh` combines
+them into `~/.config/aerospace/aerospace.toml`.
 
 It mirrors the Omarchy Hyprland tiling flow: Option + arrows focus windows,
 Option + Shift + arrows swap windows, Option + number switches workspaces, and
 Option + Shift + number moves the focused window there. Command stays available
 for normal macOS app shortcuts; use Command only in combined window-manager
-bindings such as Option + Command + Shift + number for silent moves.
+bindings such as Option + Command + Shift + number for silent moves. Option + P
+opens an app picker and moves the selected app's windows into the current workspace.
 
-Reload after linking:
+Render and reload after changing either file:
 
 ```sh
+aerospace/render-config.sh
 aerospace reload-config
 ```
 

--- a/aerospace/aerospace.toml
+++ b/aerospace/aerospace.toml
@@ -10,15 +10,23 @@ accordion-padding = 24
 
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 automatically-unhide-macos-hidden-apps = false
-persistent-workspaces = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'W']
+persistent-workspaces = ['1', '2', '4', '5', '6', '7', '8', '9', '10', 'W']
+
+[[on-window-detected]]
+check-further-callbacks = true
+run = ['layout tiling', 'balance-sizes']
 
 [[on-window-detected]]
 if.app-id = 'com.microsoft.Outlook'
 if.window-title-regex-substring = 'Reminder'
+check-further-callbacks = true
 run = 'layout floating'
 
 [[on-window-detected]]
-run = ['layout tiling', 'balance-sizes']
+if.app-name-regex-substring = '^(Safari.*|Google Chrome.*|Chromium|Firefox.*|Arc|Brave Browser.*|Microsoft Edge.*|Vivaldi|Opera.*|Orion|Zen.*|Dia|DuckDuckGo|LibreWolf|Waterfox|Floorp|SigmaOS|Sidekick)$'
+run = ['move-node-to-workspace 1', 'move --boundaries-action stop left']
+
+# __HOST_ROUTES__
 
 [key-mapping]
 preset = 'qwerty'
@@ -35,6 +43,7 @@ outer.right = 0
 # Option is the AeroSpace modifier; Command stays mostly native macOS.
 alt-enter = 'exec-and-forget open -na Ghostty || open -na Terminal'
 ctrl-backtick = 'move-node-to-workspace W'
+alt-p = 'exec-and-forget "$HOME/.config/aerospace/pull-app.sh"'
 keypadClear = 'mode workspace-prefix'
 shift-keypadClear = 'mode move-workspace-prefix'
 
@@ -63,7 +72,6 @@ cmd-alt-shift-down = 'move-workspace-to-monitor down'
 
 alt-1 = 'summon-workspace 1'
 alt-2 = 'summon-workspace 2'
-alt-3 = 'summon-workspace 3'
 alt-4 = 'summon-workspace 4'
 alt-5 = 'summon-workspace 5'
 alt-6 = 'summon-workspace 6'
@@ -73,7 +81,6 @@ alt-9 = 'summon-workspace 9'
 alt-0 = 'summon-workspace 10'
 alt-keypad1 = 'summon-workspace 1'
 alt-keypad2 = 'summon-workspace 2'
-alt-keypad3 = 'summon-workspace 3'
 alt-keypad4 = 'summon-workspace 4'
 alt-keypad5 = 'summon-workspace 5'
 alt-keypad6 = 'summon-workspace 6'
@@ -84,7 +91,6 @@ alt-keypad0 = 'summon-workspace 10'
 
 alt-shift-1 = 'move-node-to-workspace --focus-follows-window 1'
 alt-shift-2 = 'move-node-to-workspace --focus-follows-window 2'
-alt-shift-3 = 'move-node-to-workspace --focus-follows-window 3'
 alt-shift-4 = 'move-node-to-workspace --focus-follows-window 4'
 alt-shift-5 = 'move-node-to-workspace --focus-follows-window 5'
 alt-shift-6 = 'move-node-to-workspace --focus-follows-window 6'
@@ -94,7 +100,6 @@ alt-shift-9 = 'move-node-to-workspace --focus-follows-window 9'
 alt-shift-0 = 'move-node-to-workspace --focus-follows-window 10'
 alt-shift-keypad1 = 'move-node-to-workspace --focus-follows-window 1'
 alt-shift-keypad2 = 'move-node-to-workspace --focus-follows-window 2'
-alt-shift-keypad3 = 'move-node-to-workspace --focus-follows-window 3'
 alt-shift-keypad4 = 'move-node-to-workspace --focus-follows-window 4'
 alt-shift-keypad5 = 'move-node-to-workspace --focus-follows-window 5'
 alt-shift-keypad6 = 'move-node-to-workspace --focus-follows-window 6'
@@ -105,7 +110,6 @@ alt-shift-keypad0 = 'move-node-to-workspace --focus-follows-window 10'
 
 cmd-alt-shift-1 = 'move-node-to-workspace 1'
 cmd-alt-shift-2 = 'move-node-to-workspace 2'
-cmd-alt-shift-3 = 'move-node-to-workspace 3'
 cmd-alt-shift-4 = 'move-node-to-workspace 4'
 cmd-alt-shift-5 = 'move-node-to-workspace 5'
 cmd-alt-shift-6 = 'move-node-to-workspace 6'
@@ -114,8 +118,8 @@ cmd-alt-shift-8 = 'move-node-to-workspace 8'
 cmd-alt-shift-9 = 'move-node-to-workspace 9'
 cmd-alt-shift-0 = 'move-node-to-workspace 10'
 
-alt-tab = 'exec-and-forget printf "%s\n" 1 2 3 4 5 6 7 8 9 10 | aerospace workspace --wrap-around --stdin next'
-alt-shift-tab = 'exec-and-forget printf "%s\n" 1 2 3 4 5 6 7 8 9 10 | aerospace workspace --wrap-around --stdin prev'
+alt-tab = 'exec-and-forget printf "%s\n" 1 2 4 5 6 7 8 9 10 | aerospace workspace --wrap-around --stdin next'
+alt-shift-tab = 'exec-and-forget printf "%s\n" 1 2 4 5 6 7 8 9 10 | aerospace workspace --wrap-around --stdin prev'
 cmd-alt-tab = 'workspace-back-and-forth'
 
 ctrl-alt-tab = 'focus-monitor next'
@@ -139,7 +143,6 @@ esc = 'mode main'
 keypadClear = 'mode main'
 keypad1 = ['summon-workspace 1', 'mode main']
 keypad2 = ['summon-workspace 2', 'mode main']
-keypad3 = ['summon-workspace 3', 'mode main']
 keypad4 = ['summon-workspace 4', 'mode main']
 keypad5 = ['summon-workspace 5', 'mode main']
 keypad6 = ['summon-workspace 6', 'mode main']
@@ -153,7 +156,6 @@ esc = 'mode main'
 keypadClear = 'mode main'
 keypad1 = ['move-node-to-workspace --focus-follows-window 1', 'mode main']
 keypad2 = ['move-node-to-workspace --focus-follows-window 2', 'mode main']
-keypad3 = ['move-node-to-workspace --focus-follows-window 3', 'mode main']
 keypad4 = ['move-node-to-workspace --focus-follows-window 4', 'mode main']
 keypad5 = ['move-node-to-workspace --focus-follows-window 5', 'mode main']
 keypad6 = ['move-node-to-workspace --focus-follows-window 6', 'mode main']
@@ -164,10 +166,9 @@ keypad0 = ['move-node-to-workspace --focus-follows-window 10', 'mode main']
 
 [mode.service.binding]
 esc = 'mode main'
-r = ['flatten-workspace-tree', 'mode main']
+r = ['flatten-workspace-tree', 'layout h_tiles', 'mode main']
 b = ['balance-sizes', 'mode main']
 f = ['layout floating tiling', 'mode main']
-backspace = ['close-all-windows-but-current', 'mode main']
 alt-left = ['join-with left', 'mode main']
 alt-right = ['join-with right', 'mode main']
 alt-up = ['join-with up', 'mode main']

--- a/aerospace/hosts/MacBookPro.toml
+++ b/aerospace/hosts/MacBookPro.toml
@@ -1,0 +1,43 @@
+[[on-window-detected]]
+if.app-id = 'com.mitchellh.ghostty'
+run = 'move-node-to-workspace 1'
+
+[[on-window-detected]]
+if.app-id = 'com.jetbrains.intellij'
+run = 'move-node-to-workspace 1'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.VSCode'
+run = 'move-node-to-workspace 1'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.Outlook'
+run = 'move-node-to-workspace 2'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.teams2'
+run = 'move-node-to-workspace 2'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.Excel'
+run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.Word'
+run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.Powerpoint'
+run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.onenote.mac'
+run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.OneDrive'
+run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+if.app-id = 'com.microsoft.CompanyPortalMac'
+run = 'move-node-to-workspace 4'

--- a/aerospace/pull-app.sh
+++ b/aerospace/pull-app.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+workspace=$(aerospace list-workspaces --focused --format '%{workspace}')
+apps=$(aerospace list-windows --all --format '%{app-name}|%{workspace}' |
+  awk -F '|' -v workspace="$workspace" '$2 != workspace { print $1 }' |
+  sort -u)
+[ -n "$apps" ] || exit 0
+
+app=$(/usr/bin/osascript - "$apps" <<'APPLESCRIPT'
+on run argv
+  set apps to paragraphs of item 1 of argv
+  tell application "Finder"
+    activate
+    set picked to choose from list apps with title "Pull app" with prompt "Move app to the current workspace"
+  end tell
+  if picked is false then return ""
+  return item 1 of picked
+end run
+APPLESCRIPT
+)
+[ -n "$app" ] || exit 0
+
+aerospace list-windows --all --format '%{window-id}|%{app-name}|%{workspace}' |
+  awk -F '|' -v app="$app" -v workspace="$workspace" '$2 == app && $3 != workspace { print $1 }' |
+  while IFS= read -r window; do
+    aerospace move-node-to-workspace --window-id "$window" "$workspace"
+  done

--- a/aerospace/render-config.sh
+++ b/aerospace/render-config.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+config_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -P)
+host=${AEROSPACE_HOST:-$(hostname -s)}
+routes="$config_dir/hosts/$host.toml"
+destination=${AEROSPACE_CONFIG_PATH:-$HOME/.config/aerospace/aerospace.toml}
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+if [ ! -f "$routes" ]; then
+  routes=
+fi
+
+awk -v routes="$routes" '
+  $0 == "# __HOST_ROUTES__" {
+    if (routes != "") {
+      while ((getline line < routes) > 0) print line
+      close(routes)
+    }
+    next
+  }
+  { print }
+' "$config_dir/aerospace.toml" > "$tmp"
+
+mkdir -p "$(dirname "$destination")"
+rm -f "$destination"
+mv "$tmp" "$destination"
+trap - EXIT
+printf 'Rendered AeroSpace config for %s: %s\n' "$host" "$destination"

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,9 @@ usage() {
   cat <<'EOF'
 Usage: ./install.sh [--force] [--headless]
 
-Links this repo into the expected config locations:
-  ~/.config/aerospace/aerospace.toml -> aerospace/aerospace.toml
+Installs this repo into the expected config locations:
+  ~/.config/aerospace/aerospace.toml from shared config plus host routes
+  ~/.config/aerospace/pull-app.sh -> aerospace/pull-app.sh
   ~/.config/ghostty/config.ghostty -> ghostty/config.ghostty, when Ghostty is installed
   ~/.config/tmux/tmux.conf -> tmux/tmux.conf
   ~/.config/nvim           -> nvim
@@ -115,7 +116,8 @@ append_once() {
 
 mkdir -p "$HOME/.config/aerospace" "$HOME/.config/tmux" "$HOME/.config/zsh" "$tmux_plugin_dir"
 
-link_path "$repo_dir/aerospace/aerospace.toml" "$HOME/.config/aerospace/aerospace.toml"
+"$repo_dir/aerospace/render-config.sh"
+link_path "$repo_dir/aerospace/pull-app.sh" "$HOME/.config/aerospace/pull-app.sh"
 
 if [ "$headless" = true ] && [ "${DOTFILES_INSTALL_GHOSTTY:-}" != 1 ]; then
   info "Skipping Ghostty config in headless mode"


### PR DESCRIPTION
## Summary

- add host-specific AeroSpace window routing
- add an Option+P app picker that pulls windows into the current workspace
- render and install the shared plus host-specific configuration

## Checks

- `sh -n aerospace/pull-app.sh`
- `shellcheck aerospace/pull-app.sh`
- verified the picker receives keyboard focus
- reloaded the AeroSpace configuration